### PR TITLE
moved docker run from install to service

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,47 +1,5 @@
 class docker_distribution::install {
-  if $::docker_distribution::manage_as == 'container' {
-    if $::docker_distribution::http_tls_certificate {
-      $vol_cert = "${::docker_distribution::http_tls_certificate}:${::docker_distribution::http_tls_certificate}"
-    } else {
-      $vol_cert = undef
-    }
-
-    if $::docker_distribution::http_tls_key {
-      $vol_key = "${::docker_distribution::http_tls_key}:${::docker_distribution::http_tls_key}"
-    } else {
-      $vol_key = undef
-    }
-
-    if $::docker_distribution::http_tls_clientcas {
-      $vol_ca = "${::docker_distribution::http_tls_clientcas}:${::docker_distribution::http_tls_clientcas}"
-    } else {
-      $vol_ca = undef
-    }
-
-    if $::docker_distribution::mount_global_ca {
-      $vol_global_ca = "${::docker_distribution::global_ca}:/etc/ssl/certs/ca-certificates.crt"
-    } else {
-      $vol_global_ca = undef
-    }
-
-    docker::run { $::docker_distribution::package_name:
-      image           => $::docker_distribution::container_image,
-      volumes         => delete_undef_values([
-          "${::docker_distribution::config_file}:/etc/docker/registry/config.yml",
-          "${::docker_distribution::filesystem_rootdirectory}:${::docker_distribution::filesystem_rootdirectory}",
-          "${::docker_distribution::auth_token_rootcertbundle}:${::docker_distribution::auth_token_rootcertbundle}",
-          $vol_global_ca,
-          $vol_cert,
-          $vol_key,
-          $vol_ca,
-      ]),
-      restart_service => true,
-      net             => 'host',
-      detach          => false,
-      manage_service  => true,
-      running         => true,
-    }
-  } else {
+  if $::docker_distribution::manage_as == 'service' {
     package { [$::docker_distribution::package_name]: ensure => $::docker_distribution::package_ensure, }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,5 +9,46 @@ class docker_distribution::service {
       ensure => 'stopped',
       enable => false,
     }
+    if $::docker_distribution::http_tls_certificate {
+      $vol_cert = "${::docker_distribution::http_tls_certificate}:${::docker_distribution::http_tls_certificate}"
+    } else {
+      $vol_cert = undef
+    }
+
+    if $::docker_distribution::http_tls_key {
+      $vol_key = "${::docker_distribution::http_tls_key}:${::docker_distribution::http_tls_key}"
+    } else {
+      $vol_key = undef
+    }
+
+    if $::docker_distribution::http_tls_clientcas {
+      $vol_ca = "${::docker_distribution::http_tls_clientcas}:${::docker_distribution::http_tls_clientcas}"
+    } else {
+      $vol_ca = undef
+    }
+
+    if $::docker_distribution::mount_global_ca {
+      $vol_global_ca = "${::docker_distribution::global_ca}:/etc/ssl/certs/ca-certificates.crt"
+    } else {
+      $vol_global_ca = undef
+    }
+
+    docker::run { $::docker_distribution::package_name:
+      image           => $::docker_distribution::container_image,
+      volumes         => delete_undef_values([
+          "${::docker_distribution::config_file}:/etc/docker/registry/config.yml",
+          "${::docker_distribution::filesystem_rootdirectory}:${::docker_distribution::filesystem_rootdirectory}",
+          "${::docker_distribution::auth_token_rootcertbundle}:${::docker_distribution::auth_token_rootcertbundle}",
+          $vol_global_ca,
+          $vol_cert,
+          $vol_key,
+          $vol_ca,
+      ]),
+      restart_service => true,
+      net             => 'host',
+      detach          => false,
+      manage_service  => true,
+      running         => true,
+    }
   }
 }


### PR DESCRIPTION
Moved docker run from the install.pp to service.pp.  This is needed, to fix a bug on first deployment - 

running docker run before the config file gets created results in puppet errors because docker run creates /etc/docker-distribution/registry/config.yml as a directory, to satisfy the volume mount listed in the docker run command.  Then the config file creation fails, because the file already exists as a directory.